### PR TITLE
use github-url-to-object

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var http = require('http');
-var parse = require('github-url').toUrl;
+var parse = require('github-url-to-object');
 var serve = require('ecstatic')(__dirname + '/static');
 var url = require('url');
 var track = require('./lib/track');
@@ -24,10 +24,9 @@ var sync = couchSync(registry, db, meta, function (data, emit) {
         pkg.versions && Object.keys(pkg.versions).length
         && pkg.versions[Object.keys(pkg.versions).pop()].homepage
       );
+  repoUrl = parse(repoUrl);
   if (repoUrl) {
-    try { repoUrl = parse(repoUrl).replace('.git', '') }
-    catch (_) { return }
-    emit(pkg.name, repoUrl, repoUrls);
+    emit(pkg.name, repoUrl.https_url, repoUrls);
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "ecstatic": "~0.4.0",
     "ga": "0.0.2",
-    "github-url": "~1.0.0",
+    "github-url-to-object": "^1.5.2",
     "level-11": "^0.18.0",
     "level-couch-sync": "~1.0.2",
     "level-sublevel": "~4.8.0",
@@ -50,6 +50,6 @@
     "www.ghub.io"
   ],
   "bundledDependencies": [
-    "github-url"
+    "github-url-to-object"
   ]
 }

--- a/test/test.js
+++ b/test/test.js
@@ -24,10 +24,10 @@ test('not found', 'GET /sdf098sdf098', function (t, res) {
   t.body('-> https://www.npmjs.com/package/sdf098sdf098');
 });
 
-test('without repository', 'GET /jsonp', function (t, res) {
-  t.equal(res.headers.location, 'https://www.npmjs.com/package/jsonp');
+test('with repository', 'GET /jsonp', function (t, res) {
+  t.equal(res.headers.location, 'https://github.com/LearnBoost/jsonp');
   t.equal(res.statusCode, 302);
-  t.body('-> https://www.npmjs.com/package/jsonp');
+  t.body('-> https://github.com/LearnBoost/jsonp');
 });
 
 test('bitbucket', 'GET /program', function (t, res) {


### PR DESCRIPTION
This patches removes `github-url` in favor of `github-url-to-object`, the same module that the new npmjs website uses to parse repository URLs.

Repository URLs not ending with ".git", like `review`'s:

``` sh
$ npm view review repository.url
git://github.com/juliangruber/review
```

cannot be parsed by `github-url` (although there is a pull request open for this), so ironically enough the example <http://ghub.io/review> goes to the npmjs page.

In addition, packages using the new GitHub shorthand notation (`user/repo`) expand at publish-time to something that `github-url` cannot parse at all:

``` sh
$ npm view binomial-cdf repository.url
git+https://github.com/kenany/binomial-cdf.git
```

But `github-url-to-object` parses all of these.

Fixes #8 